### PR TITLE
Migrate from `gdal` + `fiona` to `pyogrio`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,59 +1,50 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "dxf2geo"
-version = "0.1.2"
-description = "Convert DXF CAD files to GIS formats like Shapefile and GeoPackage, with interactive visualisation."
-authors = [
-    { name = "Keiran Suchak", email = "ksuchak1990@yahoo.co.uk" }
-]
+version = "0.1.0"
+description = "Convert CAD DXF data into geospatial formats and visualisations using GeoPandas/Pyogrio."
 readme = "README.md"
-requires-python = ">=3.8"
-
-dependencies = [
-    "tqdm",
-    "gdal",
-    "geopandas",
-    "shapely",
-    "plotly",
-    "pandas",
-    "fiona"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "Keiran Suchak" }]
+keywords = ["GDAL", "DXF", "geospatial", "GIS", "vector", "conversion"]
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Topic :: Scientific/Engineering :: GIS",
 ]
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.envs.default]
 dependencies = [
-    "pytest",
-    "ruff",
-    "black",
-    "pytest-mock"
+  "geopandas>=1.0",
+  "pyogrio>=0.11",
+  "shapely>=2.0",
+  "pandas>=2.0",
+  "plotly>=5",
+  "tqdm>=4.66",
 ]
 
-[tool.hatch.envs.default.scripts]
-test = "pytest"
-lint = "ruff check src/ tests/"
-format = "ruff format src/ tests/"
-check-format = "ruff format --check src/ tests/"
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "pytest-mock",
+  "ruff",
+  "black",
+  "build",
+  "twine",
+]
 
-[tool.hatch.metadata]
-allow-direct-references = true
+[project.urls]
+Homepage = "https://github.com/ksuchak1990/dxf2geo"
+Repository = "https://github.com/ksuchak1990/dxf2geo"
+Issues = "https://github.com/ksuchak1990/dxf2geo/issues"
 
-[tool.ruff]
-line-length = 88
-target-version = "py38"
-fix = true
-show-fixes = true
-exclude = ["__pycache__", ".venv"]
-
-[tool.black]
-line-length = 88
-target-version = ["py38"]
-exclude = '''
-/(
-    \.venv
-  | \.git
-  | \.mypy_cache
-  | __pycache__
-)/
-'''
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/dxf2geo/visualise.py
+++ b/src/dxf2geo/visualise.py
@@ -1,18 +1,49 @@
+"""
+Visualisation utilities for DXF-derived geometries.
+
+This module provides helpers to load geospatial data written by the extraction
+pipeline into GeoPandas ``GeoDataFrame`` objects and render them as interactive
+Plotly HTML files. All I/O is routed through **Pyogrio** (the default engine
+in GeoPandas ≥ 1.0), ensuring a single, pip-friendly GDAL provider.
+
+Main entry points
+-----------------
+- :func:`load_geometries`: Load geometries from a single file or an output
+  directory structure into a combined ``GeoDataFrame``.
+- :func:`filter_modelspace_lines`: Convenience filter to exclude paper space
+  entities from CAD-derived data.
+- :func:`plot_geometries`: Quick Plotly visualisation grouped by geometry type.
+
+Notes
+-----
+- Reading and writing are performed with ``engine="pyogrio"`` for determinism.
+- Layer discovery for GeoPackage files uses :func:`pyogrio.list_layers`.
+"""
+
 from collections.abc import Iterable
 from pathlib import Path
+from typing import List, Sequence, Tuple
 
-import fiona
 import geopandas as gpd
 import pandas as pd
 import plotly.graph_objects as go
+from pyogrio import list_layers
 
 
 def _normalise_geom_labels(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
-    """Upper-case geometry labels to match plotting expectations.
+    """
+    Add an upper-case geometry type label.
 
-    GeoPandas ``.geom_type`` yields labels like "Point", "MultiLineString".
-    This function adds/overwrites a ``geometry_type`` column with upper-case
-    equivalents ("POINT", "MULTILINESTRING", etc.).
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        Input frame with a ``geometry`` column.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Copy of ``gdf`` with a new ``geometry_type`` column containing
+        upper-case geometry type names (e.g., ``'LINESTRING'``).
     """
     gdf = gdf.copy()
     gdf["geometry_type"] = gdf.geom_type.str.upper()
@@ -20,23 +51,74 @@ def _normalise_geom_labels(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
 
 
 def _read_shp(path: Path, source_label: str | None = None) -> gpd.GeoDataFrame:
-    gdf = gpd.read_file(path)
+    """
+    Read a Shapefile and annotate with geometry labels and a source tag.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to a ``.shp`` file.
+    source_label : str, optional
+        Value for the ``__source__`` column. Defaults to the file stem.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Loaded frame with ``geometry_type`` and ``__source__`` columns added.
+    """
+    gdf = gpd.read_file(path, engine="pyogrio")
     gdf = _normalise_geom_labels(gdf)
     gdf["__source__"] = source_label or path.stem
     return gdf
 
 
 def _read_gpkg_all_layers(path: Path) -> list[gpd.GeoDataFrame]:
+    """
+    Read all spatial layers from a GeoPackage.
+
+    Non-spatial tables are skipped automatically.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to a ``.gpkg`` file.
+
+    Returns
+    -------
+    list of geopandas.GeoDataFrame
+        One frame per spatial layer, each annotated with ``geometry_type`` and
+        ``__source__`` (layer name).
+    """
     gdfs: list[gpd.GeoDataFrame] = []
-    for layer in fiona.listlayers(str(path)):
-        gdf = gpd.read_file(path, layer=layer)
+    for name, gtype in list_layers(path):
+        if gtype is None:
+            continue  # skip non-spatial tables
+        gdf = gpd.read_file(path, layer=name, engine="pyogrio")
         gdf = _normalise_geom_labels(gdf)
-        gdf["__source__"] = layer
+        gdf["__source__"] = name
         gdfs.append(gdf)
     return gdfs
 
 
 def _load_from_file(file_path: Path) -> list[gpd.GeoDataFrame]:
+    """
+    Load from a single geospatial file (Shapefile or GeoPackage).
+
+    Parameters
+    ----------
+    file_path : pathlib.Path
+        Input path ending with ``.shp`` or ``.gpkg``.
+
+    Returns
+    -------
+    list of geopandas.GeoDataFrame
+        One or more frames read from the file.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is unsupported.
+    """
     ext = file_path.suffix.lower()
     if ext == ".shp":
         return [_read_shp(file_path)]
@@ -48,14 +130,29 @@ def _load_from_file(file_path: Path) -> list[gpd.GeoDataFrame]:
 def _load_from_shapefile_dir(
     root: Path, geometry_types: Iterable[str]
 ) -> list[gpd.GeoDataFrame]:
-    """Load per-type Shapefiles from <root>/<type>/<type>.shp."""
+    """
+    Load per-type Shapefiles from a directory structure.
+
+    The expected layout is ``<root>/<type>/<type>.shp`` for each geometry type.
+
+    Parameters
+    ----------
+    root : pathlib.Path
+        Root directory containing per-type Shapefile subdirectories.
+    geometry_types : Iterable[str]
+        Geometry type names (e.g., ``'POINT'``, ``'LINESTRING'``).
+
+    Returns
+    -------
+    list of geopandas.GeoDataFrame
+        Frames for each found type; missing types are ignored.
+    """
     gdfs: list[gpd.GeoDataFrame] = []
     for gtype in geometry_types:
         shp_path = root / gtype.lower() / f"{gtype.lower()}.shp"
         if shp_path.exists():
-            gdf = gpd.read_file(shp_path)
-            # Here the path implies the type; keep it explicit for plotting.
-            gdf["geometry_type"] = gtype
+            gdf = gpd.read_file(shp_path, engine="pyogrio")
+            gdf["geometry_type"] = gtype  # explicit for plotting
             gdf["__source__"] = shp_path.stem
             gdfs.append(gdf)
     return gdfs
@@ -64,7 +161,24 @@ def _load_from_shapefile_dir(
 def _load_from_gpkg_dir(
     root: Path, geometry_types: Iterable[str]
 ) -> list[gpd.GeoDataFrame]:
-    """Load per-type GeoPackages from <root>/<type>.gpkg (all layers within each)."""
+    """
+    Load per-type GeoPackages from a directory.
+
+    The expected layout is ``<root>/<type>.gpkg`` with one or more layers per
+    file. All spatial layers from each file are loaded.
+
+    Parameters
+    ----------
+    root : pathlib.Path
+        Root directory containing per-type GeoPackages.
+    geometry_types : Iterable[str]
+        Geometry type names (e.g., ``'POLYGON'``, ``'MULTILINESTRING'``).
+
+    Returns
+    -------
+    list of geopandas.GeoDataFrame
+        Frames for all spatial layers found in the per-type GeoPackages.
+    """
     gdfs: list[gpd.GeoDataFrame] = []
     for gtype in geometry_types:
         gpkg_path = root / f"{gtype.lower()}.gpkg"
@@ -74,7 +188,19 @@ def _load_from_gpkg_dir(
 
 
 def _fallback_scan_top_level(root: Path) -> list[gpd.GeoDataFrame]:
-    """If nothing matched the patterns, pick up top-level .gpkg and .shp files."""
+    """
+    Fallback loader that scans a directory for top-level ``.gpkg`` and ``.shp`` files.
+
+    Parameters
+    ----------
+    root : pathlib.Path
+        Directory to scan.
+
+    Returns
+    -------
+    list of geopandas.GeoDataFrame
+        Frames read from all discovered files.
+    """
     gdfs: list[gpd.GeoDataFrame] = []
     for gpkg in sorted(root.glob("*.gpkg")):
         gdfs.extend(_read_gpkg_all_layers(gpkg))
@@ -83,8 +209,20 @@ def _fallback_scan_top_level(root: Path) -> list[gpd.GeoDataFrame]:
     return gdfs
 
 
-def _coords_to_xy(seq):
-    """Return two lists (xs, ys) from a sequence of 2D/3D coordinates."""
+def _coords_to_xy(seq: Sequence[Sequence[float]]) -> Tuple[List[float], List[float]]:
+    """
+    Split a coordinate sequence into separate X and Y lists.
+
+    Parameters
+    ----------
+    seq : Sequence[Sequence[float]]
+        Iterable of 2D or 3D coordinates (e.g., ``[(x, y), ...]``).
+
+    Returns
+    -------
+    (list of float, list of float)
+        Two lists: ``(xs, ys)``.
+    """
     xs, ys = [], []
     for c in seq:
         xs.append(c[0])
@@ -93,6 +231,19 @@ def _coords_to_xy(seq):
 
 
 def format_hovertext(row_entry: pd.Series) -> str:
+    """
+    Construct a multi-line hover label from non-geometry attributes.
+
+    Parameters
+    ----------
+    row_entry : pandas.Series
+        Row of attributes including a Shapely geometry.
+
+    Returns
+    -------
+    str
+        HTML string with ``<br>`` separators. Geometry/meta columns are omitted.
+    """
     return (
         "<br>".join(
             f"{col}: {val}"
@@ -108,17 +259,43 @@ def load_geometries(
     input_path: Path | str, geometry_types: Iterable[str] | None = None
 ) -> gpd.GeoDataFrame:
     """
-    Load geometries from one of the following layouts:
+    Load geometries from a file or an extraction output directory.
 
-    1) a single ``.shp`` or ``.gpkg`` file;
-    2) a directory of per-type Shapefiles: ``<root>/<type>/<type>.shp``;
-    3) a directory of per-type GeoPackages: ``<root>/<type>.gpkg``;
-    4) fallback: any top-level ``.gpkg``/``.shp`` files in the directory.
+    Supported inputs
+    ----------------
+    1. Single file:
+       - ``.shp`` (Shapefile)
+       - ``.gpkg`` (GeoPackage; all spatial layers are loaded)
+    2. Directory layouts produced by the extractor:
+       - Per-type Shapefiles: ``<root>/<type>/<type>.shp``
+       - Per-type GeoPackages: ``<root>/<type>.gpkg``
+       - Fallback: any top-level ``.gpkg``/``.shp`` files in ``<root>``
 
-    Returns a combined GeoDataFrame with columns:
-    - ``geometry``
-    - ``geometry_type`` (upper-cased: POINT, LINESTRING, POLYGON, MULTILINESTRING, MULTIPOLYGON)
-    - ``__source__`` (file stem or GPKG layer name)
+    Parameters
+    ----------
+    input_path : path-like
+        Path to a file or directory as described above.
+    geometry_types : Iterable[str], optional
+        Geometry type names used to probe per-type layouts. If omitted, a
+        standard set is used (``POINT``, ``LINESTRING``, ``POLYGON``,
+        ``MULTILINESTRING``, ``MULTIPOLYGON``).
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Combined frame of all loaded features. The first non-null CRS found
+        amongst inputs is applied to the result. Contains helper columns
+        ``geometry_type`` and ``__source__``.
+
+    Raises
+    ------
+    RuntimeError
+        If no valid input can be found or no geometries are loaded.
+
+    Notes
+    -----
+    - Reads use ``engine="pyogrio"`` to ensure consistent GDAL handling.
+    - ``__source__`` holds the file stem (Shapefile) or layer name (GeoPackage).
     """
     input_path = Path(input_path).expanduser().resolve()
     if geometry_types is None:
@@ -134,29 +311,39 @@ def load_geometries(
 
     if input_path.is_file():
         gdfs = _load_from_file(input_path)
-
     elif input_path.is_dir():
-        # Prefer structured extractor layouts first.
         gdfs.extend(_load_from_shapefile_dir(input_path, geometry_types))
         gdfs.extend(_load_from_gpkg_dir(input_path, geometry_types))
-
-        # If patterns found nothing, scan top level.
         if not gdfs:
             gdfs = _fallback_scan_top_level(input_path)
-
     else:
         raise RuntimeError(f"No valid input found at {input_path}")
 
     if not gdfs:
         raise RuntimeError(f"No geometries loaded from {input_path}")
 
-    # Choose a CRS (first non-null). Users may reproject afterwards if needed.
     crs = next((g.crs for g in gdfs if g.crs is not None), None)
     gdf = gpd.GeoDataFrame(pd.concat(gdfs, ignore_index=True), crs=crs)
     return gdf
 
 
 def filter_modelspace_lines(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Remove paper-space linework from CAD-derived layers.
+
+    Many DXF/GPKG conversions preserve a ``PaperSpace`` attribute (0/1 or
+    equivalent). This helper keeps entities that are **not** in paper space.
+
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        Input frame with a ``PaperSpace`` column (numeric or coercible).
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Subset of ``gdf`` where ``PaperSpace != 1``.
+    """
     paper_space_indicator = 1.0
     paper = gdf.get("PaperSpace", pd.Series(0, index=gdf.index))
     paper = pd.to_numeric(paper, errors="coerce").fillna(0).astype(int)
@@ -164,6 +351,30 @@ def filter_modelspace_lines(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
 
 
 def plot_geometries(gdf: gpd.GeoDataFrame, output_html: Path | str) -> None:
+    """
+    Plot geometries into an interactive HTML file using Plotly.
+
+    The output groups features by ``geometry_type`` and draws points, lines,
+    and polygon exteriors with simple defaults. Non-geometry columns are
+    rendered as hover text.
+
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        Input features. Must contain ``geometry`` and ``geometry_type`` columns.
+    output_html : path-like
+        Destination path for the generated HTML file.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    - The figure uses an equal-scale axis (``yaxis_scaleanchor='x'``).
+    - ``plotly`` is used directly without specifying a theme to keep
+      dependencies light.
+    """
     fig = go.Figure()
     geometry_types = gdf.geometry_type.unique()
 
@@ -171,16 +382,14 @@ def plot_geometries(gdf: gpd.GeoDataFrame, output_html: Path | str) -> None:
         layer = gdf[gdf["geometry_type"] == geom_type]
         if layer.empty:
             continue
-
         elif geom_type in {"POINT", "MULTIPOINT"}:
             xs, ys, hover = [], [], []
             for _, row in layer.iterrows():
                 if geom_type == "POINT":
-                    # Works for 2D/3D Points
                     xs.append(row.geometry.x)
                     ys.append(row.geometry.y)
                     hover.append(format_hovertext(row))
-                else:  # MULTIPOINT
+                else:
                     for pt in row.geometry.geoms:
                         xs.append(pt.x)
                         ys.append(pt.y)
@@ -196,7 +405,6 @@ def plot_geometries(gdf: gpd.GeoDataFrame, output_html: Path | str) -> None:
                     hoverinfo="text",
                 )
             )
-
         elif geom_type in {"LINESTRING", "MULTILINESTRING"}:
             all_x, all_y, hovertext = [], [], []
             for _, row in layer.iterrows():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import warnings
+
+# Shapely 2.x deprecation touched by some pyogrio versions
+warnings.filterwarnings(
+    "ignore",
+    message="The 'shapely.geos' module is deprecated",
+    category=DeprecationWarning,
+    module=r"pyogrio(\.|$)",
+)
+
+# Optional: if any path still writes without a CRS, keep tests quiet
+warnings.filterwarnings(
+    "ignore",
+    message="'crs' was not provided",
+    category=UserWarning,
+    module=r"pyogrio\.geopandas",
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import warnings
 
-# Shapely 2.x deprecation touched by some pyogrio versions
 warnings.filterwarnings(
     "ignore",
     message="The 'shapely.geos' module is deprecated",
@@ -8,7 +7,6 @@ warnings.filterwarnings(
     module=r"pyogrio(\.|$)",
 )
 
-# Optional: if any path still writes without a CRS, keep tests quiet
 warnings.filterwarnings(
     "ignore",
     message="'crs' was not provided",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import geopandas as gpd
+
 from dxf2geo import extract
 
 
@@ -16,6 +18,19 @@ def write_minimal_dxf(path: Path) -> None:
 def test_extract_writes_gpkg(tmp_path):
     dxf = tmp_path / "test.dxf"
     write_minimal_dxf(dxf)
-    out = tmp_path / "out"
-    extract.extract_geometries(dxf, out, flatten=True, output_format="GPKG")
-    assert (out / "all_geometries.gpkg").exists()
+
+    out_dir = tmp_path / "out"
+    extract.extract_geometries(
+        dxf,
+        out_dir,
+        flatten=True,
+        output_format="GPKG",
+        assume_crs=3857,  # set a CRS; DXF has none
+    )
+
+    gpkg = out_dir / "all_geometries.gpkg"
+    assert gpkg.exists()
+
+    gdf = gpd.read_file(gpkg, engine="pyogrio")
+    assert not gdf.empty
+    assert gdf.crs is not None


### PR DESCRIPTION
Having both `fiona` and `gdal` as dependencies could cause some problems. Therefore, we are migrating to `pyogrio`. This aims to address some of the concerns raised in #4.